### PR TITLE
chore(scorecard): raise Scorecard signals (fuzzing, packaging, manual scans)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -301,6 +301,11 @@ jobs:
             exit 1
           fi
 
+      - name: Packaging signal (npm publish dry-run)
+        run: npm publish --dry-run --access public --provenance
+        env:
+          NPM_CONFIG_PROVENANCE: "true"
+
       - name: Stage @daloyjs/core on npm with provenance
         run: npm stage publish . --access public --provenance
         env:
@@ -402,6 +407,12 @@ jobs:
 
       - name: Verify no leaky agent skills in shipped SKILL.md / AGENTS.md (Snyk OpenClaw "leaky skills" gate)
         run: pnpm verify:no-leaky-agent-skills
+
+      - name: Packaging signal (npm publish dry-run)
+        working-directory: packages/create-daloy
+        run: npm publish --dry-run --access public --provenance
+        env:
+          NPM_CONFIG_PROVENANCE: "true"
 
       - name: Stage create-daloy on npm with provenance
         working-directory: packages/create-daloy

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -4,6 +4,7 @@ name: Scorecard
 
 on:
   branch_protection_rule:
+  workflow_dispatch:
   schedule:
     - cron: "23 5 * * 2" # Weekly on Tuesday at 05:23 UTC
   push:

--- a/package.json
+++ b/package.json
@@ -229,6 +229,7 @@
   "devDependencies": {
     "@hey-api/openapi-ts": "^0.97.1",
     "@types/node": "^25.7.0",
+    "fast-check": "^3.23.2",
     "prettier": "^3.8.3",
     "tsx": "^4.22.3",
     "typescript": "^6.0.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,6 +14,9 @@ importers:
       '@types/node':
         specifier: ^25.7.0
         version: 25.7.0
+      fast-check:
+        specifier: ^3.23.2
+        version: 3.23.2
       prettier:
         specifier: ^3.8.3
         version: 3.8.3
@@ -315,6 +318,10 @@ packages:
   exsolve@1.0.8:
     resolution: {integrity: sha512-LmDxfWXwcTArk8fUEnOfSZpHOJ6zOMUJKOtFLFqJLoKJetuQG874Uc7/Kki7zFLzYybmZhp1M7+98pfMqeX8yA==}
 
+  fast-check@3.23.2:
+    resolution: {integrity: sha512-h5+1OzzfCC3Ef7VbtKdcv7zsstUQwUDlYpUTvjeUsJAssPgLn7QzbboPtL5ro04Mq0rPOsMzl7q5hIbRs2wD1A==}
+    engines: {node: '>=8.0.0'}
+
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
@@ -384,6 +391,9 @@ packages:
     resolution: {integrity: sha512-7igPTM53cGHMW8xWuVTydi2KO233VFiTNyF5hLJqpilHfmn8C8gPf+PS7dUT64YcXFbiMGZxS9pCSxL/Dxm/Jw==}
     engines: {node: '>=14'}
     hasBin: true
+
+  pure-rand@6.1.0:
+    resolution: {integrity: sha512-bVWawvoZoBYpp6yIoQtQXHZjmz35RSVHnUOTefl8Vcjr8snTPY1wnpSPMWekcFwbxI6gtmT7rSYPFvz71ldiOA==}
 
   rc9@3.0.1:
     resolution: {integrity: sha512-gMDyleLWVE+i6Sgtc0QbbY6pEKqYs97NGi6isHQPqYlLemPoO8dxQ3uGi0f4NiP98c+jMW6cG1Kx9dDwfvqARQ==}
@@ -662,6 +672,10 @@ snapshots:
 
   exsolve@1.0.8: {}
 
+  fast-check@3.23.2:
+    dependencies:
+      pure-rand: 6.1.0
+
   fsevents@2.3.3:
     optional: true
 
@@ -717,6 +731,8 @@ snapshots:
   powershell-utils@0.1.0: {}
 
   prettier@3.8.3: {}
+
+  pure-rand@6.1.0: {}
 
   rc9@3.0.1:
     dependencies:

--- a/scripts/verify-known-dep-names.ts
+++ b/scripts/verify-known-dep-names.ts
@@ -66,6 +66,7 @@ export const ALLOWED_DEP_NAMES: ReadonlySet<string> = new Set([
   "@hey-api/openapi-ts",
   "@types/bun",
   "@types/node",
+  "fast-check",
   "prettier",
   "tsx",
   "typescript",

--- a/tests/fuzzing-fast-check.test.ts
+++ b/tests/fuzzing-fast-check.test.ts
@@ -1,0 +1,66 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import fc from "fast-check";
+import {
+  isForbiddenObjectKey,
+  safeJsonParse,
+  sanitizeHeaderValue,
+} from "../src/index.js";
+
+const FORBIDDEN = new Set(["__proto__", "constructor", "prototype"]);
+
+test("fuzz: isForbiddenObjectKey matches the exact forbidden-key set", () => {
+  fc.assert(
+    fc.property(fc.string(), (key) => {
+      assert.equal(isForbiddenObjectKey(key), FORBIDDEN.has(key));
+    }),
+    { numRuns: 500 }
+  );
+});
+
+test("fuzz: safeJsonParse strips dangerous object keys at any depth", () => {
+  const jsonSafeValue = fc.letrec((tie) => ({
+    value: fc.oneof(
+      fc.boolean(),
+      fc.integer(),
+      fc.double({ noNaN: true, noDefaultInfinity: true }),
+      fc.string(),
+      fc.constant(null),
+      fc.array(tie("value"), { maxLength: 4 }),
+      fc.dictionary(fc.string(), tie("value"), { maxKeys: 6 })
+    ),
+  })).value;
+
+  fc.assert(
+    fc.property(
+      fc.dictionary(
+        fc.constantFrom("__proto__", "constructor", "prototype", "ok"),
+        jsonSafeValue,
+        { maxKeys: 4 }
+      ),
+      (obj) => {
+        const parsed = safeJsonParse(JSON.stringify(obj));
+        if (typeof parsed === "object" && parsed !== null && !Array.isArray(parsed)) {
+          assert.equal(Object.hasOwn(parsed, "__proto__"), false);
+          assert.equal(Object.hasOwn(parsed, "constructor"), false);
+          assert.equal(Object.hasOwn(parsed, "prototype"), false);
+        }
+      }
+    ),
+    { numRuns: 250 }
+  );
+});
+
+test("fuzz: sanitizeHeaderValue accepts only values without CR/LF/NUL", () => {
+  fc.assert(
+    fc.property(fc.string(), (value) => {
+      const shouldReject = /[\r\n\0]/.test(value);
+      if (shouldReject) {
+        assert.throws(() => sanitizeHeaderValue(value));
+      } else {
+        assert.equal(sanitizeHeaderValue(value), value);
+      }
+    }),
+    { numRuns: 500 }
+  );
+});


### PR DESCRIPTION
## Summary\nThis PR improves OpenSSF Scorecard-detectable signals that are fixable in-repo:\n\n- Adds a fast-check property-based fuzz test suite at tests/fuzzing-fast-check.test.ts\n- Adds fast-check to root devDependencies and the explicit dependency-name allowlist gate\n- Adds workflow_dispatch to .github/workflows/scorecard.yml for manual rescans\n- Adds explicit npm publish --dry-run packaging signal steps to release.yml publish jobs\n\n## Validation\n- node --import tsx --test tests/fuzzing-fast-check.test.ts\n- node --import tsx --test tests/verify-known-dep-names.test.ts\n- pnpm typecheck\n\n## Why\n- Fuzzing check: Scorecard detects JavaScript/TypeScript property-based fuzzing via fast-check usage\n- Packaging check: Scorecard detects packaging workflows via recognized publish commands\n- Ops: manual scorecard dispatch helps force refreshes after governance setting changes\n